### PR TITLE
Refactor Azure credential handling

### DIFF
--- a/app/Assistant.Hub.Api/Core/ServiceCollectionExtensions.cs
+++ b/app/Assistant.Hub.Api/Core/ServiceCollectionExtensions.cs
@@ -1,6 +1,3 @@
-//using Azure.Storage.Blobs;
-//using Azure.Storage.Blobs.Models;
-
 using Azure.AI.OpenAI;
 using Azure;
 using Microsoft.SemanticKernel;
@@ -20,7 +17,9 @@ namespace Assistants.API.Core
 {
     internal static class ServiceCollectionExtensions
     {
-        private static readonly DefaultAzureCredential _defaultAzureCredential = new DefaultAzureCredential();
+        // this was changed slightly for issue addressed in AddAzureServices() method
+        // private static readonly DefaultAzureCredential _defaultAzureCredential = new DefaultAzureCredential();
+        private static DefaultAzureCredential _defaultAzureCredential = new();
 
         internal static IServiceCollection AddAgentLog(this IServiceCollection services, IConfiguration configuration)
         {
@@ -35,6 +34,15 @@ namespace Assistants.API.Core
 
         internal static IServiceCollection AddAzureServices(this IServiceCollection services, IConfiguration configuration)
         {
+            // For local Visual Studio based development, if you get this error:
+            //    Provided AAD token was issued by the authority [x] which is not trusted by this database account.
+            //    Please ensure the token has been issued by the AAD tenant(s) [y]
+            // You can change the tenant of your local user with this code by adding a
+            // secret named VisualStudioTenantId which contains your desired TenantId
+            if (!string.IsNullOrEmpty(configuration["VisualStudioTenantId"])) {
+                _defaultAzureCredential = new(new DefaultAzureCredentialOptions() { VisualStudioTenantId = configuration["VisualStudioTenantId"] });
+            }
+
             services.AddTransient<ContentService>();
             services.AddTransient<OcrClient>();
 

--- a/app/Assistant.Hub.Api/Services/Search/VectorSearchRetrievalPluginTool.cs
+++ b/app/Assistant.Hub.Api/Services/Search/VectorSearchRetrievalPluginTool.cs
@@ -10,6 +10,10 @@ using System.ComponentModel;
 using System.Text;
 using Azure;
 using Assistant.Hub.Api.Assistants;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Mvc;
+using MinimalApi.Services;
+using System.Diagnostics;
 
 namespace Assistant.Hub.Api.Services.Search;
 
@@ -52,6 +56,8 @@ public sealed class VectorSearchRetrievalPluginTool
 
         var key = ResolveKey(labelProperties);
         var searchClient = _searchClientFactory.GetOrCreateClient(toolDefinition.RAGSettings.RetrievalIndexName);
+
+        Debug.WriteLine($"Searching index {toolDefinition.RAGSettings.RetrievalIndexName} for key {key}...");
 
         //TODO: Handle NotFound 
         Response<ContentSearchResult> response = await searchClient.GetDocumentAsync<ContentSearchResult>(key);


### PR DESCRIPTION
If you are developing with Visual Studio locally and are trying to use your identity to get access to Azure resources and get the error message:
`Provided AAD token was issued by the authority [x] which is not trusted by this database account. Please ensure the token has been issued by the AAD tenant(s) [y].` 
or 
`Token tenant [x] does not match resource tenant.`
then your current Visual Studio user is using the wrong tenant.

This fix allows you to create a secret or appSetting with the name `VisualStudioTenantId` and then the application will get the tokens using that tenant.

---

This pull request includes several changes to the `app/Assistant.Hub.Api` directory, focusing on improving Azure service integration and adding debugging capabilities. The most important changes are outlined below:

### Improvements to Azure Service Integration:

* [`app/Assistant.Hub.Api/Core/ServiceCollectionExtensions.cs`](diffhunk://#diff-a2df41ee9e653fd42b025c44083125a46831d18229353bd23277023464f937a7L23-R22): Modified the `_defaultAzureCredential` initialization to handle local Visual Studio development issues by allowing the configuration of a specific `VisualStudioTenantId`. [[1]](diffhunk://#diff-a2df41ee9e653fd42b025c44083125a46831d18229353bd23277023464f937a7L23-R22) [[2]](diffhunk://#diff-a2df41ee9e653fd42b025c44083125a46831d18229353bd23277023464f937a7R37-R45)

### Code Cleanup:

* [`app/Assistant.Hub.Api/Core/ServiceCollectionExtensions.cs`](diffhunk://#diff-a2df41ee9e653fd42b025c44083125a46831d18229353bd23277023464f937a7L1-L3): Removed commented-out `using` statements for Azure Storage Blobs.

### Debugging Enhancements:

* [`app/Assistant.Hub.Api/Services/Search/VectorSearchRetrievalPluginTool.cs`](diffhunk://#diff-9ac54559df19c7cc768c096ed6eb75f03d3282c906292bf5c7c92807ea76dff2R60-R61): Added `Debug.WriteLine` statements to log the search index and key being used in the `SearchRetrievalAsync` method.

### Dependency Additions:

* [`app/Assistant.Hub.Api/Services/Search/VectorSearchRetrievalPluginTool.cs`](diffhunk://#diff-9ac54559df19c7cc768c096ed6eb75f03d3282c906292bf5c7c92807ea76dff2R13-R16): Added new `using` statements for `Microsoft.Extensions.Logging`, `Microsoft.AspNetCore.Mvc`, `MinimalApi.Services`, and `System.Diagnostics`.