### PR TITLE
Add documentation regarding deleting search service

### DIFF
--- a/infra/bicep/core/search/search-services.bicep
+++ b/infra/bicep/core/search/search-services.bicep
@@ -1,3 +1,14 @@
+// --------------------------------------------------------------------------------------------------------------
+// Search Service
+// --------------------------------------------------------------------------------------------------------------
+// If you have trouble deleting this resource, you may need to manually delete the associated Shared Private Access (SPL) links first:
+// $appName="XXXXXX"
+// $rgName="rg-XXXXXX-dev"
+// $envName="dev"
+// $stAcronym="st"
+// az search shared-private-link-resource delete --name link-to-storage-$appName$stAcronym$envName --service-name $appName-srch-$envName --resource-group $rgName
+// az search shared-private-link-resource delete --name link-to-openai-$appName-cog-$envName --service-name $appName-srch-$envName --resource-group $rgName
+// --------------------------------------------------------------------------------------------------------------
 param name string = ''
 param location string = resourceGroup().location
 param tags object = {}


### PR DESCRIPTION
This pull request adds a new section to the `infra/bicep/core/search/search-services.bicep` file to provide guidance on managing Search Service resources. The most important change includes documentation for handling Shared Private Access (SPL) links when deleting the resource.

Resource management documentation:

* [`infra/bicep/core/search/search-services.bicep`](diffhunk://#diff-d6378613e74ba79a8f7de31f8e7db306900660a5a353a57175857df6707570a6R1-R11): Added comments explaining how to manually delete associated Shared Private Access (SPL) links using Azure CLI commands if there are issues deleting the Search Service resource.